### PR TITLE
Fix/1203466796723268 rust version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cargo build --release
 or you can use below commands
 ```bash
 cd ../peaq-network-node
-docker run --rm -it -v $(pwd):/sources rust-stable:ubuntu-20.04 cargo build --release --manifest-path=/sources/Cargo.toml
+docker run --rm -it -v $(pwd):/sources -w /sources rust-stable:ubuntu-20.04 cargo build --release
 ```
 
 The built binary will be on the host machine, under peaq-network-node/target/release/peaq-node
@@ -38,9 +38,9 @@ If we want to build the node which supports the EVM tracing module, we have to f
 cd ../peaq-network-node
 
 # Build runtime module
-docker run --rm -it --env CARGO_TARGET_DIR="/sources/target_runtime" -v $(pwd):/sources rust-stable:ubuntu-20.04 cargo build --release -p peaq-node-runtime --features "std aura evm-tracing" --manifest-path=/sources/Cargo.toml
+docker run --rm -it --env CARGO_TARGET_DIR="/sources/target_runtime" -v $(pwd):/sources -w /sources rust-stable:ubuntu-20.04 cargo build --release -p peaq-node-runtime --features "std aura evm-tracing"
 # Build node
-docker run --rm -it -v $(pwd):/sources rust-stable:ubuntu-20.04 cargo build --release --manifest-path=/sources/Cargo.toml
+docker run --rm -it -v $(pwd):/sources -w /sources rust-stable:ubuntu-20.04 cargo build --release
 ```
 
 After building the runtime module and node, we can start a node by replacing the runtime module with EVM tracing feature.
@@ -66,6 +66,6 @@ If you want to build RBAC, you can follow below commands
 
 ```bash
 cd ../RBAC
-docker run --rm -it -v $(pwd):/sources rust-stable:ubuntu-20.04 cargo +nightly contract build --manifest-path=/sources/Cargo.toml
-docker run --rm -it -v $(pwd):/sources rust-stable:ubuntu-20.04 cargo +nightly contract test --manifest-path=/sources/Cargo.toml
+docker run --rm -it -v $(pwd):/sources -w /sources rust-stable:ubuntu-20.04 cargo +nightly contract build
+docker run --rm -it -v $(pwd):/sources -w /sources rust-stable:ubuntu-20.04 cargo +nightly contract test
 ```

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -2,12 +2,16 @@ FROM ubuntu:20.04
 
 WORKDIR /root
 
+RUN export TZ=Europe/Berlin
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
 # common packages
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
     ca-certificates curl file \
     build-essential \
-    git clang curl libssl-dev llvm libudev-dev \
+    git clang curl libssl-dev llvm libudev-dev cmake \
     autoconf automake autotools-dev libtool xutils-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
1. Change the current directory because we'll set up the rust version in the project.
2. The CMake is needed for building the dependency in parachain.